### PR TITLE
Add compiler version to fix error in build output and failed build

### DIFF
--- a/GettingStartedWithCodeBuild/pom.xml
+++ b/GettingStartedWithCodeBuild/pom.xml
@@ -6,6 +6,10 @@
   <artifactId>messageUtil</artifactId>
   <version>1.0</version>
   <packaging>jar</packaging>
+  <properties>
+     <maven.compiler.source>11</maven.compiler.source>
+     <maven.compiler.target>11</maven.compiler.target>
+  </properties>
   <name>Message Utility Java Sample App</name>
   <dependencies>
     <dependency>


### PR DESCRIPTION
Fixes this error in CodeBuild output, Maven defaults to version java 1.5,
```sh
[StackOverflow Question](https://stackoverflow.com/questions/59685437/java-maven-project-source-option-5-is-no-longer-supported-use-6-or-later)
[ERROR] COMPILATION ERROR :
[INFO] ------------------------------------------------------------- 
[ERROR] Source option 5 is no longer supported. Use 6 or later. 
[ERROR] Target option 1.5 is no longer supported. Use 1.6 or later.
```

================================================== 
**After update to version 11 (1.8 also works)**
```sh
Downloaded from central: https://repo.maven.apache.org/maven2/org/codehaus/plexus/plexus-digest/1.0/plexus-digest-1.0.jar (12 kB at 791 kB/s) 
[INFO] Installing /codebuild/output/src913801100/src/target/messageUtil-1.0.jar to /root/.m2/repository/org/example/messageUtil/1.0/messageUtil-1.0.jar [INFO] Installing /codebuild/output/src913801100/src/pom.xml to /root/.m2/repository/org/example/messageUtil/1.0/messageUtil-1.0.pom 
[INFO]
------------------------------------------------------------------------ 
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------ 
[INFO] Total time:  6.650 s
[INFO] Finished at: 2022-09-27T13:46:10Z
[INFO] ------------------------------------------------------------------------
```